### PR TITLE
Fix incorrect label example in deployment selector explanation

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,7 +39,7 @@ spec:
 
 其中  `kind` 表示我们要创建的资源是 `deployment` 类型，  `metadata.name` 表示要创建的 deployment 的名字，这个名字需要是**唯一**的。
 
-在 `spec` 里面表示，首先 `replicas` 表示的是部署的 pod 副本数量，`selector` 里面表示的是 `deployment` 资源和 `pod` 资源关联的方式，这里表示 `deployment` 会管理 (selector) 所有 `labels=hellok8s` 的 pod。
+在 `spec` 里面表示，首先 `replicas` 表示的是部署的 pod 副本数量，`selector` 里面表示的是 `deployment` 资源和 `pod` 资源关联的方式，这里表示 `deployment` 会管理 (selector) 所有 `labels=app: hellok8s` 的 pod。
 
 `template` 的内容是用来定义 `pod` 资源的，你会发现和作业一：Hellok8s Pod 资源的定义是差不多的，唯一的区别是我们需要加上 `metadata.labels` 来和上面的 `selector.matchLabels` 对应起来。来表明 pod 是被 deployment 管理，不用在`template` 里面加上 `metadata.name` 是因为 deployment 会主动为我们创建 pod 的唯一`name`。
 


### PR DESCRIPTION
According to the [official Kubernetes docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#:~:text=Labels%20and%20Selectors-,Labels%20are%20key/value%20pairs,-that%20are%20attached), labels are defined as key/value pairs. The previous wording could confuse readers into thinking labels are single string values.